### PR TITLE
fix: Electrobun 1.16 RPC integration (v0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-05-01
+
+slaido (Electrobun 1.16) からのフィードバック (#1, #2, #3) を反映した緊急バグ修正リリース。
+v0.1.0 は Electrobun 1.16 上で実質的に動作しなかったため、本バージョンを最初に動く版と位置付ける。
+
+### Fixed
+
+- **#1**: `src/scripts.ts` の全 builder が `new Function(script)()` 経由で実行されたとき結果が常に `undefined` になる問題を修正。式を `return (...);` で wrap し、Promise を返すスクリプトも `return new Promise(...);` の形に揃えた。Electrobun 1.16 builtin RPC (`api/browser/index.ts:142`) の handler に整合
+- **#2**: `BunMotView.rpc.request.evaluateJavascriptWithResponse` のシグネチャを Electrobun 1.16 builtin RPC schema (`params: { script: string }`) に揃えた。`src/bridge.ts` の 3 箇所の呼び出しも `{ script }` 形に変更
+
+### Changed (BREAKING)
+
+- `BunMotView` 型: `evaluateJavascriptWithResponse(script: string)` → `evaluateJavascriptWithResponse(params: { script: string })`。Electrobun 1.16 の `webview` を直接渡しているコードには影響なし。独自に `view` を組み立てている場合は要修正
+
+### Documentation
+
+- **#3**: README §1.5 を追加し、mainview 側で `new Electroview({ rpc: Electroview.defineRPC({ handlers: { requests: {}, messages: {} } }) })` の構築が必要なことを明記。`__electrobunSendToHost()` だけ使っているアプリで bun-mot を入れたとき RPC transport が確立されず全リクエストが timeout する症状の hint を併記
+
 ### Added
 
 - `.github/workflows/release.yml`: タグ push (`v*`) で OIDC Trusted Publishing による `npm publish --provenance --access public` を実行し、CHANGELOG から該当バージョンを抽出して GitHub Release を作成する CI
@@ -62,5 +80,6 @@
 - 2026-05-01 に v0.1.0 を npm に publish 済み (https://www.npmjs.com/package/bun-mot/v/0.1.0)
 - Trusted Publisher (`release.yml` 経由の OIDC publish) は v0.1.0 公開後に npmjs.com 側で登録する設計
 
-[Unreleased]: https://github.com/hummer98/bun-mot/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/hummer98/bun-mot/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/hummer98/bun-mot/releases/tag/v0.1.1
 [0.1.0]: https://github.com/hummer98/bun-mot/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -58,16 +58,42 @@ if (process.env.BUN_MOT_PORT) {
 
 > **Note**: use **identifier access** (`process.env.BUN_MOT_PORT`), not bracket access (`process.env["BUN_MOT_PORT"]`). Bun's `--env='BUN_MOT_*'` build-time inlining only matches identifier form.
 
-The `view` argument is anything that satisfies this shape. Electrobun's `BrowserView` / `webview` already does.
+The `view` argument is anything that satisfies this shape. Electrobun's `BrowserView` / `webview` already does (the signature matches Electrobun 1.16's builtin RPC).
 
 ```typescript
 interface BunMotView {
   rpc: {
     request: {
-      evaluateJavascriptWithResponse(script: string): Promise<unknown>;
+      evaluateJavascriptWithResponse(params: { script: string }): Promise<unknown>;
     };
   };
 }
+```
+
+### 1.5. App side: initialize `Electroview` in mainview
+
+bun-mot drives the WebView through Electrobun's RPC transport. The transport's request handler (`evaluateJavascriptWithResponse`) is registered by the **`Electroview` constructor on the browser side** — without it, every command from bun-mot times out before it ever reaches your DOM.
+
+If your mainview only uses `__electrobunSendToHost()` style messaging (no bun → browser RPC), you have probably never instantiated `Electroview`. Add it now:
+
+```typescript
+// app/views/mainview/index.ts
+import { Electroview } from "electrobun/view";
+
+new Electroview({
+  rpc: Electroview.defineRPC({ handlers: { requests: {}, messages: {} } }),
+});
+```
+
+If you already define your own request / message handlers, pass them through the same `defineRPC` call.
+
+Symptom you will see if this is missing (from the bridge log):
+
+```
+[bridge_started] port=4747 hostname=127.0.0.1
+[command_received] type=evaluate expression=1+1
+[console_patch_failed] phase=bootstrap message="RPC request timed out."
+[command_completed] type=evaluate success=false durationMs=1002 kind=evaluation_error
 ```
 
 ### 2. Test side: drive it with `BunMot`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bun-mot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "E2E testing driver for Electrobun apps. Playwright-compatible API for asserting on real WebView state via an HTTP bridge.",
   "license": "MIT",
   "author": "Yuji Yamamoto",

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -184,7 +184,7 @@ async function ensureConsolePatch(view: BunMotView, state: BridgeState): Promise
   if (!state.bootstrapPromise) {
     state.bootstrapPromise = (async (): Promise<void> => {
       try {
-        await view.rpc.request.evaluateJavascriptWithResponse(buildConsolePatchScript());
+        await view.rpc.request.evaluateJavascriptWithResponse({ script: buildConsolePatchScript() });
         state.bootstrappedAtLeastOnce = true;
         log("console_patch_applied", { phase: "bootstrap" });
       } catch (e) {
@@ -198,7 +198,7 @@ async function ensureConsolePatch(view: BunMotView, state: BridgeState): Promise
   if (!state.bootstrappedAtLeastOnce) return;
   // navigation / reload 復旧用。失敗してもメインコマンド実行は継続。
   try {
-    await view.rpc.request.evaluateJavascriptWithResponse(buildEnsurePatchScript());
+    await view.rpc.request.evaluateJavascriptWithResponse({ script: buildEnsurePatchScript() });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     log("console_patch_ensure_failed", { message });
@@ -269,7 +269,7 @@ async function dispatchCommand(cmd: CommandRequest, view: BunMotView): Promise<u
   let scriptPromise: Promise<unknown>;
   try {
     const script = buildScriptForCommand(cmd);
-    scriptPromise = view.rpc.request.evaluateJavascriptWithResponse(script);
+    scriptPromise = view.rpc.request.evaluateJavascriptWithResponse({ script });
   } catch (e) {
     throw new InternalDispatchError(e);
   }

--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -1,6 +1,11 @@
 // WebView (Electrobun) に注入する JS 文字列のビルダー。
 // すべて Promise を返す式として組み立て、evaluateJavascriptWithResponse 経由で resolve/reject させる。
 // reject 文字列は prefix で kind を識別 (§4.4)。
+//
+// 重要: Electrobun 1.16 の builtin extraRequestHandler は `new Function(script)()` で実行する
+// (electrobun/api/browser/index.ts:142)。`new Function(body)()` は body の最後に return 文が
+// 無いと結果が常に undefined になるため、各 builder は **必ず `return ...;` で値を返す形** に
+// すること。consolePatch / ensurePatch のような副作用専用 IIFE のみ return 不要。
 
 import type { TextMatcher } from "./commands";
 
@@ -31,7 +36,7 @@ function buildMutationWaitScript(opts: MutationWaitOpts): string {
   const raf = opts.withRaf
     ? `\n  requestAnimationFrame(() => {\n    if (check()) done();\n  });`
     : "";
-  return `new Promise((resolve, reject) => {
+  return `return new Promise((resolve, reject) => {
   const SELECTOR = ${sel};
   const TIMEOUT = ${t};
   const start = Date.now();
@@ -60,8 +65,9 @@ ${raf}
 }
 
 export function buildEvaluateScript(expression: string): string {
-  // 任意式をそのまま渡す。値は evaluateJavascriptWithResponse が JSON シリアライズして返す。
-  return expression;
+  // 任意式を `return (...)` で wrap して値を返す。new Function(body)() で評価される前提。
+  // 値は evaluateJavascriptWithResponse が JSON シリアライズして返す (Promise なら await される)。
+  return `return (${expression});`;
 }
 
 export function buildWaitForSelectorScript(selector: string, timeout: number): string {
@@ -69,7 +75,7 @@ export function buildWaitForSelectorScript(selector: string, timeout: number): s
   // rAF フォールバック 1 回のみ許容。
   const sel = JSON.stringify(selector);
   const t = String(timeout);
-  return `new Promise((resolve, reject) => {
+  return `return new Promise((resolve, reject) => {
   const SELECTOR = ${sel};
   const TIMEOUT = ${t};
   const start = Date.now();
@@ -102,7 +108,7 @@ export function buildWaitForSelectorScript(selector: string, timeout: number): s
 
 export function buildGetTextScript(selector: string): string {
   const sel = JSON.stringify(selector);
-  return `new Promise((resolve, reject) => {
+  return `return new Promise((resolve, reject) => {
   const el = document.querySelector(${sel});
   if (!el) { reject('__BUNMOT_SELECTOR_NOT_FOUND__:' + ${sel}); return; }
   resolve({ text: el.textContent ?? '' });
@@ -111,7 +117,7 @@ export function buildGetTextScript(selector: string): string {
 
 export function buildClickScript(selector: string): string {
   const sel = JSON.stringify(selector);
-  return `new Promise((resolve, reject) => {
+  return `return new Promise((resolve, reject) => {
   const el = document.querySelector(${sel});
   if (!el) { reject('__BUNMOT_SELECTOR_NOT_FOUND__:' + ${sel}); return; }
   if (!(el instanceof HTMLElement)) {
@@ -126,7 +132,7 @@ export function buildClickScript(selector: string): string {
 export function buildFillScript(selector: string, value: string): string {
   const sel = JSON.stringify(selector);
   const val = JSON.stringify(value);
-  return `new Promise((resolve, reject) => {
+  return `return new Promise((resolve, reject) => {
   const el = document.querySelector(${sel});
   if (!el) { reject('__BUNMOT_SELECTOR_NOT_FOUND__:' + ${sel}); return; }
   const isInput = el instanceof HTMLInputElement;
@@ -169,7 +175,7 @@ function isVisibleJsExpr(): string {
 
 export function buildIsVisibleScript(selector: string): string {
   const sel = JSON.stringify(selector);
-  return `new Promise((resolve) => {
+  return `return new Promise((resolve) => {
   const isVisibleFn = ${isVisibleJsExpr()};
   const el = document.querySelector(${sel});
   resolve({ visible: isVisibleFn(el) });
@@ -179,7 +185,7 @@ export function buildIsVisibleScript(selector: string): string {
 export function buildGetAttributeScript(selector: string, attribute: string): string {
   const sel = JSON.stringify(selector);
   const attr = JSON.stringify(attribute);
-  return `new Promise((resolve, reject) => {
+  return `return new Promise((resolve, reject) => {
   const el = document.querySelector(${sel});
   if (!el) { reject('__BUNMOT_SELECTOR_NOT_FOUND__:' + ${sel}); return; }
   const v = el.getAttribute(${attr});
@@ -291,7 +297,7 @@ export function buildEnsurePatchScript(): string {
 }
 
 export function buildGetLogsScript(): string {
-  return `new Promise((resolve) => {
+  return `return new Promise((resolve) => {
   const buf = window.__BUNMOT_LOGS__;
   if (!buf || typeof buf.drain !== 'function') {
     resolve({ entries: [], droppedCount: 0, patchMissing: true });
@@ -309,7 +315,7 @@ export function buildScreenshotScript(opts: { fullPage: boolean }): string {
   const target = opts.fullPage ? "document.documentElement" : "document.body";
   // html2canvasSource はライブラリ本体 (UMD)。eval すると window.html2canvas を立ち上げる。
   // ソース内でのシングルクォート / バッククォートは UMD バンドルの構造を壊さないようそのまま埋め込む。
-  return `(async () => {
+  return `return (async () => {
   if (!window.__bunmot_html2canvas) {
     ${html2canvasSource};
     window.__bunmot_html2canvas = window.html2canvas;
@@ -324,5 +330,5 @@ export function buildScreenshotScript(opts: { fullPage: boolean }): string {
   const PREFIX_LEN = "data:image/png;base64,".length;
   const byteCount = Math.floor((dataUrl.length - PREFIX_LEN) * 3 / 4);
   return { dataUrl: dataUrl, byteCount: byteCount };
-})()`;
+})();`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,11 +12,14 @@ export type ErrorKind =
   | "element_not_interactable"
   | "internal_error";
 
-// Electrobun BrowserView の最小インタフェース (ダックタイピング)
+// Electrobun BrowserView の最小インタフェース (ダックタイピング)。
+// Electrobun 1.16 builtin RPC のシグネチャに合わせて `{ script }` オブジェクト形で受け取る
+// (electrobun/api/browser/builtinrpcSchema.ts: `params: { script: string }`)。
+// 直接 `view.webview` を渡せば型整合する想定。
 export interface BunMotView {
   rpc: {
     request: {
-      evaluateJavascriptWithResponse(script: string): Promise<unknown>;
+      evaluateJavascriptWithResponse(params: { script: string }): Promise<unknown>;
     };
   };
 }

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -12,13 +12,18 @@ afterAll(() => {
   delete process.env["BUN_MOT_LOG"];
 });
 
+// テスト本体は引数を string で受け取りたいので、ここで Electrobun 1.16 の
+// `{ script }` シグネチャから string への adapter を挟む。
 type EvalImpl = (script: string) => Promise<unknown>;
+type MockEval = (params: { script: string }) => Promise<unknown>;
 
 function createMockView(evalImpl: EvalImpl): {
   view: BunMotView;
-  evaluateMock: ReturnType<typeof mock<EvalImpl>>;
+  evaluateMock: ReturnType<typeof mock<MockEval>>;
 } {
-  const evaluateMock = mock(evalImpl);
+  const evaluateMock = mock<MockEval>(async (params: { script: string }) =>
+    evalImpl(params.script),
+  );
   const view: BunMotView = {
     rpc: { request: { evaluateJavascriptWithResponse: evaluateMock } },
   };
@@ -122,7 +127,7 @@ describe("POST /command - 正常系", () => {
     const lastCall = calls[calls.length - 1];
     expect(lastCall).toBeDefined();
     if (lastCall) {
-      expect(lastCall[0]).toContain("5000");
+      expect(lastCall[0]?.script).toContain("5000");
     }
     bridge.stop();
   });
@@ -239,7 +244,7 @@ describe("POST /command - エラーマッピング", () => {
           // 同期的に throw する
           evaluateJavascriptWithResponse: ((): never => {
             throw new Error("internal boom");
-          }) as unknown as (script: string) => Promise<unknown>,
+          }) as unknown as (params: { script: string }) => Promise<unknown>,
         },
       },
     };
@@ -494,7 +499,7 @@ describe("Console patch bootstrap / ensure", () => {
     const calls = evaluateMock.mock.calls;
     // 最初の呼び出しが bootstrap script
     expect(calls.length).toBeGreaterThanOrEqual(2);
-    const first = calls[0]?.[0] as string | undefined;
+    const first = calls[0]?.[0]?.script as string | undefined;
     expect(first).toBeDefined();
     expect(first ?? "").toContain("__BUNMOT_LOGS__");
     expect(first ?? "").toContain("MAX");
@@ -511,7 +516,9 @@ describe("Console patch bootstrap / ensure", () => {
     // 2 回目: ensure (1) + 実コマンド (1) = 2 増。bootstrap は呼ばれない。
     expect(callsAfterSecond - callsAfterFirst).toBe(2);
     // ensure script は !window.__BUNMOT_LOGS__ ガードを持つ
-    const ensureCall = evaluateMock.mock.calls[callsAfterFirst]?.[0] as string | undefined;
+    const ensureCall = evaluateMock.mock.calls[callsAfterFirst]?.[0]?.script as
+      | string
+      | undefined;
     expect(ensureCall ?? "").toContain("!window.__BUNMOT_LOGS__");
     bridge.stop();
   });
@@ -521,7 +528,11 @@ describe("Console patch bootstrap / ensure", () => {
     const view: BunMotView = {
       rpc: {
         request: {
-          evaluateJavascriptWithResponse: async (script: string): Promise<unknown> => {
+          evaluateJavascriptWithResponse: async ({
+            script,
+          }: {
+            script: string;
+          }): Promise<unknown> => {
             callCount++;
             // bootstrap (= 最初の patch script) のみ reject。
             if (
@@ -550,7 +561,11 @@ describe("Console patch bootstrap / ensure", () => {
     const view: BunMotView = {
       rpc: {
         request: {
-          evaluateJavascriptWithResponse: async (script: string): Promise<unknown> => {
+          evaluateJavascriptWithResponse: async ({
+            script,
+          }: {
+            script: string;
+          }): Promise<unknown> => {
             // bootstrap reject
             if (
               script.includes("MAX") &&

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -20,7 +20,17 @@ afterAll(() => {
 
 function startBridge(evalImpl: (script: string) => Promise<unknown>): BunMotBridge {
   const view: BunMotView = {
-    rpc: { request: { evaluateJavascriptWithResponse: evalImpl } },
+    rpc: {
+      request: {
+        // Electrobun 1.16 builtin RPC は `{ script }` 形で受け取るので、test 側の
+        // string ベース evalImpl をここで adapter する。
+        evaluateJavascriptWithResponse: async ({
+          script,
+        }: {
+          script: string;
+        }): Promise<unknown> => evalImpl(script),
+      },
+    },
   };
   return setupBunMot(view, { port: 0 });
 }
@@ -121,8 +131,9 @@ describe("BunMotClient.send - エラーマッピング", () => {
       rpc: {
         request: {
           evaluateJavascriptWithResponse: ((): never => {
+            // 同期 throw の動作確認用。型は { script } 形でキャストするだけ。
             throw new Error("boom");
-          }) as unknown as (script: string) => Promise<unknown>,
+          }) as unknown as (params: { script: string }) => Promise<unknown>,
         },
       },
     };

--- a/test/driver.test.ts
+++ b/test/driver.test.ts
@@ -19,7 +19,9 @@ afterAll(() => {
   delete process.env["BUN_MOT_LOG"];
 });
 
+// テスト本体は string ベースで evalImpl を書きたいので、ここで adapter を挟む。
 type EvalImpl = (script: string) => Promise<unknown>;
+type MockEval = (params: { script: string }) => Promise<unknown>;
 type CapturedRequest = {
   type: string;
   expression?: string;
@@ -34,7 +36,7 @@ type CapturedRequest = {
 
 interface BridgeHarness {
   port: number;
-  evalMock: ReturnType<typeof mock<EvalImpl>>;
+  evalMock: ReturnType<typeof mock<MockEval>>;
   receivedRequests: CapturedRequest[];
   stop: () => void;
 }
@@ -49,7 +51,9 @@ async function startCapturingBridge(
   evalImpl: EvalImpl,
   responseFor?: (req: CapturedRequest) => ResponseImpl | undefined,
 ): Promise<BridgeHarness> {
-  const evalMock = mock(evalImpl);
+  const evalMock = mock<MockEval>(async (params: { script: string }) =>
+    evalImpl(params.script),
+  );
   const view: BunMotView = {
     rpc: { request: { evaluateJavascriptWithResponse: evalMock } },
   };
@@ -73,7 +77,7 @@ async function startCapturingBridge(
         });
       }
       try {
-        const result = await evalMock("dummy");
+        const result = await evalMock({ script: "dummy" });
         return new Response(JSON.stringify({ success: true, result }), {
           status: 200,
           headers: { "content-type": "application/json" },

--- a/test/fixtures/sample-app/main.ts
+++ b/test/fixtures/sample-app/main.ts
@@ -11,12 +11,18 @@ const port = Number(process.env["BUN_MOT_PORT"] ?? "0");
 const dummyView: BunMotView = {
   rpc: {
     request: {
-      // 最小スタブ: 受け取った script を eval する。
+      // 最小スタブ: Electrobun 1.16 builtin の `evaluateJavascriptWithResponse` と同じ
+      // `new Function(script)()` 経路で実行する (api/browser/index.ts:142 と等価)。
       // scripts.ts 由来の document.querySelector を含む script は ReferenceError で reject され、
       // bridge 側で `evaluation_error` に分類される (本フィクスチャのスコープ外)。
-      evaluateJavascriptWithResponse: async (script: string): Promise<unknown> => {
-        // eslint-disable-next-line no-eval
-        return eval(script);
+      evaluateJavascriptWithResponse: async ({
+        script,
+      }: {
+        script: string;
+      }): Promise<unknown> => {
+        const fn = new Function(script);
+        const result = fn();
+        return result instanceof Promise ? await result : result;
       },
     },
   },

--- a/test/manual-curl-check.ts
+++ b/test/manual-curl-check.ts
@@ -8,21 +8,22 @@ import type { BunMotView } from "../src/types";
 const view: BunMotView = {
   rpc: {
     request: {
-      evaluateJavascriptWithResponse: async (script: string): Promise<unknown> => {
-        // 簡易 mock: evaluate なら eval (※検証用、本番では使わない)
-        if (script.startsWith("new Promise")) {
-          // waitForSelector / getText の Promise script は WebView 環境がないと動かないので
-          // 検証では simple resolve を返す
-          if (script.includes("__BUNMOT_TIMEOUT__")) {
-            return { found: true };
-          }
-          if (script.includes("textContent")) {
-            return { text: "mock-text" };
-          }
+      evaluateJavascriptWithResponse: async ({
+        script,
+      }: {
+        script: string;
+      }): Promise<unknown> => {
+        // 簡易 mock: scripts.ts は `return new Promise(...)` 形で来る (issue #1)。
+        // WebView 環境がないと実行できないので、典型ケースのみ short-circuit する。
+        if (script.includes("__BUNMOT_TIMEOUT__")) {
+          return { found: true };
+        }
+        if (script.includes("textContent")) {
+          return { text: "mock-text" };
         }
         try {
-          // 危険: 検証用のみ
-          return Function("return " + script)();
+          // 危険: 検証用のみ。Electrobun 1.16 と同じく new Function(script)() で実行。
+          return new Function(script)();
         } catch (e) {
           throw e;
         }

--- a/test/scripts.test.ts
+++ b/test/scripts.test.ts
@@ -16,9 +16,85 @@ import {
 } from "../src/scripts";
 
 describe("buildEvaluateScript", () => {
-  test("式をそのまま返す (透過)", () => {
-    expect(buildEvaluateScript("1 + 1")).toBe("1 + 1");
-    expect(buildEvaluateScript("document.title")).toBe("document.title");
+  // Electrobun 1.16 builtin RPC は `new Function(script)()` で実行する。
+  // body に return が無いと結果が常に undefined になるため、`return (expr);` で wrap する。
+  test("式を `return (expr);` で wrap する", () => {
+    expect(buildEvaluateScript("1 + 1")).toBe("return (1 + 1);");
+    expect(buildEvaluateScript("document.title")).toBe("return (document.title);");
+  });
+
+  test("new Function(script)() で評価すると値が返る", () => {
+    expect(new Function(buildEvaluateScript("1 + 1"))()).toBe(2);
+    expect(new Function(buildEvaluateScript("'a' + 'b'"))()).toBe("ab");
+  });
+});
+
+describe("scripts: new Function(script)() で実行可能 (Electrobun 1.16 互換性)", () => {
+  // issue #1 回帰防止: bridge は scripts.ts の戻り値を Electrobun の builtin handler に
+  // そのまま渡し、handler 側で `new Function(script)()` 経由で実行される。
+  // 各 builder は最低限「Promise を返す」もしくは「同期的に値を返す」必要がある。
+  test("buildWaitForSelectorScript は Promise を返す", () => {
+    const result = new Function(buildWaitForSelectorScript(".never", 0))();
+    expect(result).toBeInstanceOf(Promise);
+    // 0ms timeout なので reject されるはずだが、ここでは ID として捨てる
+    void (result as Promise<unknown>).catch(() => {});
+  });
+
+  test("buildGetTextScript は Promise を返す", () => {
+    const result = new Function(buildGetTextScript("h1"))();
+    expect(result).toBeInstanceOf(Promise);
+    void (result as Promise<unknown>).catch(() => {});
+  });
+
+  test("buildClickScript は Promise を返す", () => {
+    const result = new Function(buildClickScript(".btn"))();
+    expect(result).toBeInstanceOf(Promise);
+    void (result as Promise<unknown>).catch(() => {});
+  });
+
+  test("buildFillScript は Promise を返す", () => {
+    const result = new Function(buildFillScript(".x", "v"))();
+    expect(result).toBeInstanceOf(Promise);
+    void (result as Promise<unknown>).catch(() => {});
+  });
+
+  test("buildIsVisibleScript は Promise を返す", () => {
+    const result = new Function(buildIsVisibleScript(".x"))();
+    expect(result).toBeInstanceOf(Promise);
+    void (result as Promise<unknown>).catch(() => {});
+  });
+
+  test("buildGetAttributeScript は Promise を返す", () => {
+    const result = new Function(buildGetAttributeScript(".x", "data-id"))();
+    expect(result).toBeInstanceOf(Promise);
+    void (result as Promise<unknown>).catch(() => {});
+  });
+
+  test("buildWaitForHiddenScript は Promise を返す", () => {
+    const result = new Function(buildWaitForHiddenScript(".x", 0))();
+    expect(result).toBeInstanceOf(Promise);
+    void (result as Promise<unknown>).catch(() => {});
+  });
+
+  test("buildWaitForTextScript は Promise を返す", () => {
+    const result = new Function(
+      buildWaitForTextScript(".x", { kind: "string", value: "v" }, 0),
+    )();
+    expect(result).toBeInstanceOf(Promise);
+    void (result as Promise<unknown>).catch(() => {});
+  });
+
+  test("buildGetLogsScript は Promise を返す", () => {
+    const result = new Function(buildGetLogsScript())();
+    expect(result).toBeInstanceOf(Promise);
+    void (result as Promise<unknown>).catch(() => {});
+  });
+
+  test("buildScreenshotScript は Promise を返す", () => {
+    // html2canvas が無い環境では reject されるが、ここでは return 値が Promise であることだけ確認
+    const result = new Function(buildScreenshotScript({ fullPage: true }))();
+    expect(result).toBeInstanceOf(Promise);
+    void (result as Promise<unknown>).catch(() => {});
   });
 });
 


### PR DESCRIPTION
## Summary

slaido (Electrobun 1.16) からのフィードバック (#1, #2, #3) を一括修正。
v0.1.0 は Electrobun 1.16 上で実質動作不能だったため、本 PR を最初に動く版 (v0.1.1) として位置付ける。

- **#1**: \`src/scripts.ts\` の全 builder を \`return ...;\` 形に変更。Electrobun builtin handler (\`api/browser/index.ts:142\`) は \`new Function(script)()\` 経由で実行するため、\`return\` が無いと結果が常に \`undefined\` になる
- **#2**: \`BunMotView.rpc.request.evaluateJavascriptWithResponse\` のシグネチャを Electrobun 1.16 builtin RPC schema (\`params: { script: string }\`) に揃える。\`src/bridge.ts\` の 3 箇所の呼び出しも \`{ script }\` 形に変更
- **#3**: README §1.5 を追加し、mainview 側で \`new Electroview({ rpc: Electroview.defineRPC({ handlers: { requests: {}, messages: {} } }) })\` の構築が必要なことを明記

Closes #1, #2, #3.

## Breaking change

- \`BunMotView.evaluateJavascriptWithResponse\` のシグネチャ: \`(script: string)\` → \`(params: { script: string })\`
  - Electrobun の \`webview\` を直接渡しているコードには影響なし
  - 独自に \`view\` を組み立てているコードは要修正 (Electrobun 1.16 builtin RPC schema に揃えただけなので、移行は機械的)

## Test plan

- [x] \`bun test\` (278 pass / 13 files)
- [x] \`bun run prepublishOnly\` (typecheck + test:unit + build) で 274 unit test 全 pass
- [x] \`scripts.test.ts\` に \`new Function(script)()\` 経由の戻り値検証 (Promise 返却 / evaluate の値返却) を追加して回帰防止
- [ ] **要レビュー**: 実 Electrobun 1.16 アプリ (slaido) で issue 内のコマンドが期待結果を返すこと
  - \`curl -X POST http://127.0.0.1:4747/command -d '{"type":"evaluate","expression":"1+1"}'\` → \`{"success":true,"result":2}\`
  - \`curl -X POST http://127.0.0.1:4747/command -d '{"type":"waitForSelector","selector":"#seed-input","timeout":10000}'\` → \`{"success":true,"result":{"found":true}}\`

## Out of scope

- #4 (\`launch()\` の複合起動コマンド対応・\`attach()\` API): API 設計判断が必要なため別 PR (v0.2.0 想定)
- #5 (bootstrap retry / timeout 設定): 別 PR (v0.2.0 想定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)